### PR TITLE
introduce unit:NCM and further specify unit:SCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
   - `unit:BasePair` which is implied by `unit:GigaBasePair`
   - `unit:FLOPS` which is implied by e.g `unit:TeraFLOPS`
   - `unit:Ci` (deprecated) which is implied by e.g. now-deprecated `unit:KiloCi`
+  - `unit:NCM` to support the Dutch hydrocarbons sector
+  - `unit:NCM_1ATM_0DEG_C_NL` which is quantified further by `unit:NCM`
+  - `unit:SCM_1ATM_0DEG_C` which is a contextual unit of `unit:SCM`
+  - `unit:SCM_1ATM_15DEG_C_ISO` which is a contextual unit of `unit:SCM`
+  - `unit:SCM_1ATM_15DEG_C_NL` which is a Dutch hydrocarbons sector quantification of `unit:SCM`
 
 ### Changed
 
@@ -53,6 +58,7 @@ and this project is in the process of adopting [Semantic Versioning](https://sem
 - Descriptions
   - Changed "Thermal heat capacity" to "total energy per unit mass, commonly known as specific enthalpy" for unit:BTU_TH-PER-LB
   - Changed "Thermal heat capacity" to "total energy per unit mass, commonly known as specific enthalpy" for unit:J-PER-KiloGM
+  - Further specified sources for, and applications of, unit:SCM and derivatives, including linking to unit:NCM
 
 ### Deprecated
 

--- a/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
+++ b/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
@@ -1131,6 +1131,15 @@ unit:SCF
 
 unit:SCM
   qudt:scalingOf unit:MOL .
+  
+unit:SCM_1ATM_0DEG_C
+  qudt:scalingOf unit:MOL .
+
+unit:SCM_1ATM_15DEG_C_ISO
+  qudt:scalingOf unit:MOL .
+
+unit:SCM_1ATM_15DEG_C_NL
+  qudt:scalingOf unit:MOL .
 
 unit:SH
   qudt:scalingOf unit:SEC .

--- a/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
+++ b/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
@@ -804,6 +804,12 @@ unit:N
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
   ] .
+  
+unit:NCM
+  qudt:scalingOf unit:MOL .
+
+unit:NCM_1ATM_0DEG_C_NL
+  qudt:scalingOf unit:MOL .
 
 unit:NT
   qudt:scalingOf unit:M3 .
@@ -1131,7 +1137,7 @@ unit:SCF
 
 unit:SCM
   qudt:scalingOf unit:MOL .
-  
+
 unit:SCM_1ATM_0DEG_C
   qudt:scalingOf unit:MOL .
 

--- a/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
+++ b/src/build/inference/factorUnits/predefined-factors-and-scalings.ttl
@@ -804,7 +804,7 @@ unit:N
     qudt:exponent -2 ;
     qudt:hasUnit unit:SEC ;
   ] .
-  
+
 unit:NCM
   qudt:scalingOf unit:MOL .
 

--- a/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/src/main/rdf/vocab/unit/VOCAB_QUDT-UNITS-ALL.ttl
@@ -35255,6 +35255,42 @@ unit:N
   rdfs:label "न्यूटन"@hi ;
   rdfs:label "ニュートン"@ja ;
   rdfs:label "牛顿"@zh .
+  
+unit:NCM
+  a qudt:Unit ;
+  dcterms:description """
+The $\\textit{normal cubic metre}$ is a unit representing the amount of a product contained in a volume of one cubic metre at reference 'normal' temperature and pressure conditions. As such, it is a measure of the actual amount of product, most commonly referring to oil, not the volume of the product. The reference conditions for normal cubic metre vary depending on purpose and application.
+  """^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "https://www.wikidata.org/entity/Q350023"^^xsd:anyURI ;
+  qudt:scalingOf unit:MOL ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Normal Cubic Meter"@en-US ;
+  rdfs:label "Normal Cubic Metre"@en ;
+  rdfs:label "Normkubikmeter"@de ;
+  rdfs:seeAlso unit:SCM .
+
+unit:NCM_1ATM_0DEG_C_NL
+  a qudt:ContextualUnit, qudt:Unit ;
+  dcterms:description """
+The $\\textit{normal cubic metre}$ is a unit for liquid products conforming to the Dutch Mining Regulations (Mijnbouwregeling) for reporting in the Dutch oil and gas industry, and used predominantly for crude oil. As such, it is a measure of the actual amount of oil, not the volume of the oil. The reference conditions for a Dutch normal cubic metre are 0 degrees Celsius at 1 standard atmosphere (atm), equivalent to 101.325 kilopascals (kPa) of pressure.
+  """^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "http://wetten.overheid.nl/jci1.3:c:BWBR0014468&hoofdstuk=11&paragraaf=11.3&artikel=11.3.1"^^xsd:anyURI ;
+  qudt:informativeReference "https://nl.wikipedia.org/wiki/Normaal_kubieke_meter"^^xsd:anyURI ;
+  qudt:informativeReference "https://open.overheid.nl/Details/fefb9108-c56d-453a-badb-c2ad144da3a1/2"^^xsd:anyURI ;
+  qudt:scalingOf unit:MOL ;
+  qudt:symbol "Nm³" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Normaal Kubieke Meter"@nl ;
+  rdfs:label "Normal Cubic Metre"@en ;
+  rdfs:seeAlso unit:SCM .
 
 unit:N-CentiM
   a qudt:Unit ;
@@ -45147,13 +45183,16 @@ not the volume of the gas. The reference conditions for standard cubic metre are
   """^^qudt:LatexString ;
   qudt:conversionMultiplier 42.3105 ;
   qudt:conversionMultiplierSN 4.23105E1 ;
+  qudt:exactMatch unit:SCM_1ATM_0DEG_C ;
   qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
-  qudt:informativeReference "https://en.wikipedia.org/wiki/Standard_cubic_foot"^^xsd:anyURI ;
+  qudt:informativeReference "doi:10.1016/B978-1-933762-00-5.50012-8"^^xsd:anyURI ;
+  qudt:informativeReference "ncim:C2348523"^^xsd:anyURI ;
   qudt:symbol "scm" ;
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Standard Cubic Meter"@en-US ;
-  rdfs:label "Standard Cubic Metre"@en .
+  rdfs:label "Standard Cubic Metre"@en ;
+  rdfs:seeAlso unit:NCM .
 
 unit:SCM-PER-HR
   a qudt:Unit ;
@@ -45188,6 +45227,56 @@ not the volume of the gas. The reference conditions for standard cubic metre per
   rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
   rdfs:label "Standard Cubic Meter per Minute"@en-US ;
   rdfs:label "Standard Cubic Metre per Minute"@en .
+
+unit:SCM_1ATM_0DEG_C
+  a qudt:ContextualUnit, qudt:Unit ;
+  dcterms:description """
+The $\\textit{standard cubic metre}$ (scm) is a unit representing the amount of gas (such as natural gas) contained in a volume of one cubic metre at reference temperature and pressure conditions. As such, it is a measure of the actual amount of gas, not the volume of the gas. The reference conditions for standard cubic metre are 0 degrees Celsius and 101.325 kilopascals (kPa) of pressure.
+  """^^qudt:LatexString ;
+  qudt:applicableSystem sou:USCS ;
+  qudt:conversionMultiplier 42.3105 ;
+  qudt:conversionMultiplierSN 4.23105E1 ;
+  qudt:exactMatch unit:SCM ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Standard_cubic_foot"^^xsd:anyURI ;
+  qudt:symbol "scm" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Standard Cubic Meter"@en-US ;
+  rdfs:label "Standard Cubic Metre"@en .
+
+unit:SCM_1ATM_15DEG_C_ISO
+  a qudt:ContextualUnit, qudt:Unit ;
+  dcterms:description """
+A $\\textit{standard cubic metre}$ as defined by ISO 91:2017, generally applicable within the oil and gas sectors. The reference conditions for an ISO standard cubic metre are 15 degrees Celsius at 1 standard atmosphere (atm), equivalent to 101.325 kilopascals (kPa) of pressure following ISO 2533:1975.
+  """^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "urn:iso:std:iso:91:ed-1:v1"^^xsd:anyURI ;
+  qudt:informativeReference "urn:iso:std:iso:2533:ed-1:v1"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Standard Cubic Metre"@en .
+
+unit:SCM_1ATM_15DEG_C_NL
+  a qudt:ContextualUnit, qudt:Unit ;
+  dcterms:description """
+The definition of a $\\textit{standard cubic metre}$ conforming to the Dutch Mining Regulations (Mijnbouwregeling) for reporting figures in the Dutch oil and gas industry, and used for liquids except brine (pekel). The reference conditions for a Dutch standard cubic metre are 15 degrees Celsius at 1 standard atmosphere (atm), equivalent to 101.325 kilopascals (kPa) of pressure.
+  """^^qudt:LatexString ;
+  qudt:applicableSystem sou:SI ;
+  qudt:conversionMultiplier 0.0 ;
+  qudt:conversionMultiplierSN 0.0E0 ;
+  qudt:exactMatch unit:SCM_1ATM_15DEG_C_ISO ;
+  qudt:hasDimensionVector qkdv:A1E0L0I0M0H0T0D0 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:informativeReference "http://wetten.overheid.nl/jci1.3:c:BWBR0014468&hoofdstuk=11&paragraaf=11.3&artikel=11.3.1"^^xsd:anyURI ;
+  qudt:informativeReference "https://open.overheid.nl/Details/fefb9108-c56d-453a-badb-c2ad144da3a1/2"^^xsd:anyURI ;
+  qudt:symbol "Sm³" ;
+  rdfs:isDefinedBy <http://qudt.org/$$QUDT_VERSION$$/vocab/unit> ;
+  rdfs:label "Standaard Kubieke Meter"@nl ;
+  rdfs:label "Standard Cubic Metre"@en .
 
 unit:SEC
   a qudt:Unit ;


### PR DESCRIPTION
Further to #1227 allows for international use of unit:SCM and improves cross linking to other units.
Further defines normal cubic metre for use in the dutch hydrocarbon industry